### PR TITLE
Handle NULL option as default

### DIFF
--- a/Database/Functions/LocalToUtc.sql
+++ b/Database/Functions/LocalToUtc.sql
@@ -13,7 +13,7 @@ BEGIN
     DECLARE @ZoneId int
     SET @ZoneId = [Tzdb].GetZoneId(@tz)
 
-    IF @FirstOnFallBackOverlap = 1
+    IF @FirstOnFallBackOverlap = 1 OR @FirstOnFallBackOverlap IS NULL
         SELECT TOP 1 @OffsetMinutes = [OffsetMinutes]
         FROM [Tzdb].[Intervals]
         WHERE [ZoneId] = @ZoneId


### PR DESCRIPTION
If NULL is supplied to the @FirstOnFallBackOverlap parameter then the function uses the non-default action instead of the default. For this reason I have added a check for NULL. It is okay for the @SkipOnSpringForwardGap case as there is a test against 0 that requires it to be explicitly set for non-default behaviour.
