### PR TITLE
Remove App.config as it doesn't work any more

### DIFF
--- a/SqlTzLoader/App.config
+++ b/SqlTzLoader/App.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-  </startup>
-  <connectionStrings>
-    <add name="tzdb" connectionString="Server=.;Database=Tzdb;Trusted_Connection=True" />
-  </connectionStrings>
-</configuration>

--- a/SqlTzLoader/SqlTzLoader.csproj
+++ b/SqlTzLoader/SqlTzLoader.csproj
@@ -52,7 +52,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Took me a while to figure out that based on the pull from last December (#8), the App.config file doesn't work any more, but never got deleted. Deleting here.

Not my project, but I would actually argue that it would be better to add the fallback to the app config back in (and I would be happy to do so). I need to extend this to only bring in certain time zones based either on a time zone list or country code (with country code being preferred for me personally as time zones get added with some frequency). In either case, it would be helpful to be able to specify a list in the app config file. We have to deploy this to self hosted customers who know nothing about how to manage servers. It's much easier to give them a config file then teach them about how to set up and change command line args.
