### PR TITLE
Some sensible optimizations to functions

### DIFF
--- a/Database/Database.sqlproj
+++ b/Database/Database.sqlproj
@@ -81,5 +81,6 @@
     <Build Include="Functions\ConvertZone.sql" />
     <Build Include="Functions\GetZoneAbbreviation.sql" />
     <Build Include="Functions\GetZoneId.sql" />
+    <Build Include="Functions\GetZoneId_Inline.sql" />
   </ItemGroup>
 </Project>

--- a/Database/Functions/GetZoneId_Inline.sql
+++ b/Database/Functions/GetZoneId_Inline.sql
@@ -1,0 +1,11 @@
+﻿CREATE FUNCTION [tzdb].GetZoneId_Inline
+(
+	@tz VARCHAR(50)
+
+) 
+RETURNS TABLE WITH SCHEMABINDING AS 
+RETURN (
+	SELECT ISNULL(l.CanonicalZoneId, z.Id) AS ZoneId
+	FROM Tzdb.Zones z LEFT JOIN Tzdb.Links l ON l.LinkZoneId = z.Id
+	WHERE z.Name = @tz
+)

--- a/Database/Functions/UtcToLocal.sql
+++ b/Database/Functions/UtcToLocal.sql
@@ -1,20 +1,18 @@
-﻿CREATE FUNCTION [Tzdb].[UtcToLocal]
+﻿CREATE FUNCTION Tzdb.UtcToLocal
 (
-    @utc datetime2,
-    @tz varchar(50)
+    @utc DATETIME2,
+    @tz VARCHAR(50)
 )
-RETURNS datetimeoffset
-AS
+RETURNS DATETIMEOFFSET
+WITH SCHEMABINDING AS
 BEGIN
-    DECLARE @OffsetMinutes int
+    DECLARE @OffsetMinutes INT
 
-    DECLARE @ZoneId int
-    SET @ZoneId = [Tzdb].GetZoneId(@tz)
 
     SELECT TOP 1 @OffsetMinutes = [OffsetMinutes]
-    FROM [Tzdb].[Intervals]
-    WHERE [ZoneId] = @ZoneId
-      AND [UtcStart] <= @utc AND [UtcEnd] > @utc
+    FROM [Tzdb].[Intervals] i INNER JOIN Tzdb.GetZoneId_Inline(@tz) z ON i.ZoneId = z.ZoneId
+    WHERE  [UtcStart] <= @utc AND [UtcEnd] > @utc
 
     RETURN TODATETIMEOFFSET(DATEADD(MINUTE, @OffsetMinutes, @utc), @OffsetMinutes)
 END
+GO


### PR DESCRIPTION
Creates an inline table valued function to get the zone id from the links table.

Uses that inline function in UtcToLocal and LocalToUTC

Schema binds functions
- note that this will require scripts to be run in a certain order. Don't know what tool you are using to generate, it doesn't appear to be a standard publish, but be aware that this matters

I was seeing some decent performance improvement from this. Processing 70,000 dates went from about 25 seconds to about 17. I don't like this metric, I would rather pay attention to actual reads/writes/cpu, but that data is hard to get for non-inline functions as the query optimizer black boxes them.

Turns out that writing an inline version of UtcToLocal actually makes things worse. Probably a result of the query optimizer choking on the complexity from the cross applies that end up being used. SQL Server is fun that way.

IMO, it would make sense to just keep duplicate data in the intervals table for all the linked time zones, instead of running a query to get the canonical timezone from the link, and then looking up that time zone. This allows basic inner joins to retrieve data, instead of functions, and that's always going to perform better. Should more than make up for the extra rows in the table (especially since the table is never written). As an added bonus, you can create some indexed views you otherwise wouldn't be able to create.

I also wonder what would happen if the clustered index on the zones table were just the IANA zone name (lose the surrogate key). Yes, it's wide, but that puts the cluster on the primary lookup column, which is good.

Let me know if you want me to try any of this stuff.
