### PR TITLE
Give names to pk

### DIFF
--- a/Database/Tables/Intervals.sql
+++ b/Database/Tables/Intervals.sql
@@ -8,7 +8,7 @@
     [LocalEnd] DATETIME2(0) NOT NULL,
     [OffsetMinutes] SMALLINT NOT NULL,
     [Abbreviation] VARCHAR(10) NOT NULL,
-    CONSTRAINT [PK_Intervals] PRIMARY KEY ([Id])
+    CONSTRAINT [PK_Intervals] PRIMARY KEY ([Id]),
     CONSTRAINT [FK_Intervals_Zones] FOREIGN KEY ([ZoneId]) REFERENCES [Tzdb].[Zones]([Id])
 )
 

--- a/Database/Tables/Intervals.sql
+++ b/Database/Tables/Intervals.sql
@@ -1,6 +1,6 @@
 ﻿CREATE TABLE [Tzdb].[Intervals]
 (
-    [Id] INT NOT NULL PRIMARY KEY IDENTITY(1,1),
+    [Id] INT NOT NULL IDENTITY(1,1),
     [ZoneId] INT NOT NULL,
     [UtcStart] DATETIME2(0) NOT NULL,
     [UtcEnd] DATETIME2(0) NOT NULL,
@@ -8,6 +8,7 @@
     [LocalEnd] DATETIME2(0) NOT NULL,
     [OffsetMinutes] SMALLINT NOT NULL,
     [Abbreviation] VARCHAR(10) NOT NULL,
+    CONSTRAINT [PK_Intervals] PRIMARY KEY ([Id])
     CONSTRAINT [FK_Intervals_Zones] FOREIGN KEY ([ZoneId]) REFERENCES [Tzdb].[Zones]([Id])
 )
 

--- a/Database/Tables/Links.sql
+++ b/Database/Tables/Links.sql
@@ -1,7 +1,8 @@
 ﻿CREATE TABLE [Tzdb].[Links]
 (
-    [LinkZoneId] INT NOT NULL PRIMARY KEY, 
+    [LinkZoneId] INT NOT NULL, 
     [CanonicalZoneId] INT NOT NULL, 
+    CONSTRAINT [PK_Links] PRIMARY KEY ([LinkZoneId]),
     CONSTRAINT [FK_Links_Zones_1] FOREIGN KEY ([LinkZoneId]) REFERENCES [Tzdb].[Zones]([Id]), 
-    CONSTRAINT [FK_Links_Zones_2] FOREIGN KEY ([CanonicalZoneId]) REFERENCES [Tzdb].[Zones]([Id]) 
+    CONSTRAINT [FK_Links_Zones_2] FOREIGN KEY ([CanonicalZoneId]) REFERENCES [Tzdb].[Zones]([Id])
 )

--- a/Database/Tables/VersionInfo.sql
+++ b/Database/Tables/VersionInfo.sql
@@ -1,5 +1,6 @@
 ﻿CREATE TABLE [Tzdb].[VersionInfo]
 (
-    [Version] CHAR(5) NOT NULL PRIMARY KEY, 
-    [Loaded] DATETIMEOFFSET(0) NOT NULL
+    [Version] CHAR(5) NOT NULL, 
+    [Loaded] DATETIMEOFFSET(0) NOT NULL,
+    CONSTRAINT [PK_VersionInfo] PRIMARY KEY ([Version])
 )

--- a/Database/Tables/Zones.sql
+++ b/Database/Tables/Zones.sql
@@ -1,7 +1,8 @@
 ﻿CREATE TABLE [Tzdb].[Zones]
 (
-    [Id] INT NOT NULL PRIMARY KEY IDENTITY(1,1), 
-    [Name] VARCHAR(50) NOT NULL
+    [Id] INT NOT NULL IDENTITY(1,1), 
+    [Name] VARCHAR(50) NOT NULL,
+    CONSTRAINT [PK_Zones] PRIMARY KEY([Id])
 )
 
 GO


### PR DESCRIPTION
Hi Matt,

This is rather simple change. I've created DB objects using your script so on different environments (DEV\UAT\PROD) primary key constraints have different system-generated names. It is OK until you are comparing environments one against other and see these differences every time.

I think it can be useful for other setups too.

Thank you,
Alexander
