### PR TITLE
Update to latest Noda and .NET 4.7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ UpgradeLog*.XML
 
 # Debug Data Directories
 App_Data
+.cr/

--- a/NodaTime.CurrentTzdbProvider/NodaTime.CurrentTzdbProvider.csproj
+++ b/NodaTime.CurrentTzdbProvider/NodaTime.CurrentTzdbProvider.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NodaTime</RootNamespace>
     <AssemblyName>NodaTime.CurrentTzdbProvider</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NodaTime">
-      <HintPath>..\packages\NodaTime.1.3.1\lib\net35-Client\NodaTime.dll</HintPath>
+    <Reference Include="NodaTime, Version=3.0.2.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NodaTime.3.0.2\lib\netstandard2.0\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -43,6 +44,9 @@
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/NodaTime.CurrentTzdbProvider/NodaTime.CurrentTzdbProvider.csproj
+++ b/NodaTime.CurrentTzdbProvider/NodaTime.CurrentTzdbProvider.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NodaTime, Version=3.0.2.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
-      <HintPath>..\packages\NodaTime.3.0.2\lib\netstandard2.0\NodaTime.dll</HintPath>
+    <Reference Include="NodaTime, Version=3.0.5.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NodaTime.3.0.5\lib\netstandard2.0\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/NodaTime.CurrentTzdbProvider/packages.config
+++ b/NodaTime.CurrentTzdbProvider/packages.config
@@ -3,5 +3,6 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="NodaTime" version="1.3.1" targetFramework="net45" />
+  <package id="NodaTime" version="3.0.2" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
 </packages>

--- a/NodaTime.CurrentTzdbProvider/packages.config
+++ b/NodaTime.CurrentTzdbProvider/packages.config
@@ -3,6 +3,6 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="NodaTime" version="3.0.2" targetFramework="net472" />
+  <package id="NodaTime" version="3.0.5" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
 </packages>

--- a/SqlTzLoader/Program.cs
+++ b/SqlTzLoader/Program.cs
@@ -90,7 +90,7 @@ namespace SqlTzLoader
 
         private static async Task WriteIntervalsAsync(IDictionary<string, int> zones, CurrentTzdbProvider tzdb)
         {
-            var currentUtcYear = SystemClock.Instance.Now.InUtc().Year;
+            var currentUtcYear = SystemClock.Instance.GetCurrentInstant().InUtc().Year;
             var maxYear = currentUtcYear + 5;
             var maxInstant = new LocalDate(maxYear + 1, 1, 1).AtMidnight().InUtc().ToInstant();
 
@@ -114,12 +114,12 @@ namespace SqlTzLoader
                     var intervals = tzdb[id].GetZoneIntervals(Instant.MinValue, maxInstant);
                     foreach (var interval in intervals)
                     {
-
-                        var utcStart = interval.Start == Instant.MinValue
+                        
+                        var utcStart = !interval.HasStart
                             ? DateTime.MinValue
                             : interval.Start.ToDateTimeUtc();
 
-                        var utcEnd = interval.End == Instant.MaxValue
+                        var utcEnd = !interval.HasEnd
                             ? DateTime.MaxValue
                             : interval.End.ToDateTimeUtc();
 
@@ -147,6 +147,7 @@ namespace SqlTzLoader
 
                         dt.Rows.Add(utcStart, utcEnd, localStart, localEnd, offsetMinutes, abbreviation);
                     }
+                    if (_options.Verbose) Console.WriteLine("Processing: {0}", id);
 
                     var cs = _options.ConnectionString;
                     using (var connection = new SqlConnection(cs))

--- a/SqlTzLoader/SqlTzLoader.csproj
+++ b/SqlTzLoader/SqlTzLoader.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SqlTzLoader</RootNamespace>
     <AssemblyName>SqlTzLoader</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -36,13 +37,16 @@
       <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NodaTime">
-      <HintPath>..\packages\NodaTime.1.3.1\lib\net35-Client\NodaTime.dll</HintPath>
+    <Reference Include="NodaTime, Version=3.0.2.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NodaTime.3.0.2\lib\netstandard2.0\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -52,6 +56,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/SqlTzLoader/SqlTzLoader.csproj
+++ b/SqlTzLoader/SqlTzLoader.csproj
@@ -37,8 +37,8 @@
       <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NodaTime, Version=3.0.2.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
-      <HintPath>..\packages\NodaTime.3.0.2\lib\netstandard2.0\NodaTime.dll</HintPath>
+    <Reference Include="NodaTime, Version=3.0.5.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NodaTime.3.0.5\lib\netstandard2.0\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/SqlTzLoader/app.config
+++ b/SqlTzLoader/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/SqlTzLoader/packages.config
+++ b/SqlTzLoader/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
-  <package id="NodaTime" version="1.3.1" targetFramework="net45" />
+  <package id="NodaTime" version="3.0.2" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
 </packages>

--- a/SqlTzLoader/packages.config
+++ b/SqlTzLoader/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net45" />
-  <package id="NodaTime" version="3.0.2" targetFramework="net472" />
+  <package id="NodaTime" version="3.0.5" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Moved project dependencies up to latest noda time which should get the latest timezone definitions. Fixed a few API changes.